### PR TITLE
Switch to google-api-client >= 0.9

### DIFF
--- a/google_drive-persistent_session.gemspec
+++ b/google_drive-persistent_session.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'google-api-client', '~> 0.8.0'
-  spec.add_dependency 'google_drive', '~> 1.0'
+  spec.add_dependency 'google-api-client', '>= 0.9.0'
+  spec.add_dependency 'google_drive', '>= 2.0.0'
   spec.add_dependency 'highline'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/lib/google_drive/persistent_session.rb
+++ b/lib/google_drive/persistent_session.rb
@@ -1,6 +1,5 @@
 require 'fileutils'
 require 'forwardable'
-require 'google/api_client'
 require 'google_drive'
 require 'highline'
 

--- a/lib/google_drive/persistent_session/credential_storage.rb
+++ b/lib/google_drive/persistent_session/credential_storage.rb
@@ -1,3 +1,5 @@
+require 'google/api_client/auth/storage'
+
 module GoogleDrive::CredentialStorage
   DEFAULE_FILE_STORE_PATH = '~/.google_drive-oauth2.json'
 

--- a/lib/google_drive/persistent_session/file_store_ext.rb
+++ b/lib/google_drive/persistent_session/file_store_ext.rb
@@ -1,3 +1,5 @@
+require 'google/api_client/auth/storages/file_store'
+
 class Google::APIClient::FileStore
   alias write_credentials_orig write_credentials
 


### PR DESCRIPTION
google-api-client 0.9 have many changes including incompatibilities.
https://github.com/google/google-api-ruby-client/blob/0.9/MIGRATING.md#migrating-from-version-08x-to-09
google/api_client has removed.
google_drive >= 2.0.0 supports google-api-client >= 0.9, so I've updated
both version dependencies.
https://github.com/gimite/google-drive-ruby/blob/v2.0.0/MIGRATING.md#migrating-from-version-1xx-to-2xx