### PR TITLE
Use loopback IP address redirect instead of OOB flow

### DIFF
--- a/google_drive-persistent_session.gemspec
+++ b/google_drive-persistent_session.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'google_drive', '>= 3.0.7'
   spec.add_dependency 'highline'
+  spec.add_dependency 'webrick'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
 end

--- a/lib/google_drive/persistent_session/persistent_session.rb
+++ b/lib/google_drive/persistent_session/persistent_session.rb
@@ -1,3 +1,7 @@
+require 'securerandom'
+require 'uri'
+require 'webrick'
+
 class GoogleDrive::PersistentSession
   extend Forwardable
   include GoogleDrive::CredentialStorage
@@ -35,6 +39,42 @@ class GoogleDrive::PersistentSession
     client_secret = ask('Enter CLIENT SECRET: ') {|q| q.echo = false }
     puts # line break
 
+    # Use loopback IP address redirect option
+    # https://developers.google.com/identity/protocols/oauth2/native-app#redirect-uri_loopback
+    server = WEBrick::HTTPServer.new(Port: 0, AccessLog: [])
+    queue = Thread::SizedQueue.new(1)
+    health_token = SecureRandom.uuid
+    server.mount_proc('/') do |req, resp|
+      resp.content_type = 'text/plain'
+      if req.request_method != 'GET'
+        resp.status = 405
+        res.body = 'Method Not Allowed'
+        next
+      end
+
+      case req.path
+      when '/'
+        # redirect
+        params = URI.decode_www_form(req.query_string).to_h
+        if params.key?('code')
+          code = params.fetch('code')
+          resp.status = 200
+          resp.body = 'Successfully authorized. Back to console'
+          queue.push(code)
+        else
+          resp.status = 400
+          resp.body = 'Failed to authorize: code is missing'
+          queue.push(nil)
+        end
+      when '/health'
+        resp.status = 200
+        resp.body = health_token
+      else
+        resp.status = 404
+        resp.body = 'not found'
+      end
+    end
+    server_thread = Thread.start { server.start }
     credential =  Google::Auth::UserRefreshCredentials.new(
       :client_id => client_id,
       :client_secret => client_secret,
@@ -42,18 +82,45 @@ class GoogleDrive::PersistentSession
         'https://www.googleapis.com/auth/drive',
         'https://spreadsheets.google.com/feeds/'
       ],
-      :redirect_uri => 'urn:ietf:wg:oauth:2.0:oob',
+      :redirect_uri => "http://127.0.0.1:#{server.config[:Port]}",
       :grant_type => 'authorization_code'
     )
 
-    fetch_access_token(credential)
+    server_launched = false
+    60.times do |i|
+      begin
+        resp = Net::HTTP.get_response('127.0.0.1', '/health', server.config[:Port])
+        resp.value
+        if resp.body == health_token
+          server_launched = true
+          break
+        else
+          $stderr.puts "  Server returned unknown response: #{resp.body}"
+          sleep 1
+        end
+      rescue => e
+        $stderr.puts "  Waiting server launch: #{e.class}: #{e.message}"
+        sleep 1
+      end
+    end
+    unless server_launched
+      server.shutdown
+      server_thread.join
+      raise 'Failed to start HTTP server'
+    end
+    fetch_access_token(credential, queue, server, server_thread)
     storage.write_credentials(credential)
   end
 
-  def fetch_access_token(credential)
-    message =  "1. Open this page:\n%s\n\n" % credential.authorization_uri
-    message << "2. Enter the authorization code shown in the page: "
-    credential.code = ask(message)
+  def fetch_access_token(credential, queue, server, server_thread)
+    puts "Open this page in web browser: #{credential.authorization_uri}"
+    code = queue.pop
+    server.shutdown
+    server_thread.join
+    unless code
+      raise 'authorization failed'
+    end
+    credential.code = code
 
     credential.fetch_access_token!
     storage.write_credentials(credential)


### PR DESCRIPTION
OOB flow is now deprecated and will be blocked.
https://developers.googleblog.com/2022/02/making-oauth-flows-safer.html#disallowed-oob
The alternative way to use OAuth from CLI is loopback IP address
redirect.
https://developers.google.com/identity/protocols/oauth2/native-app#redirect-uri_loopback

Example new authorization flow looks like below.

```ruby
require 'google_drive/persistent_session'

session = GoogleDrive::PersistentSession.login
```

```
% bundle exec ruby example.rb
Enter CLIENT ID: xxxxxx.apps.googleusercontent.com
Enter CLIENT SECRET:

[2022-08-26 11:49:16] INFO  WEBrick 1.7.0
[2022-08-26 11:49:16] INFO  ruby 2.7.6 (2022-04-12) [x86_64-linux]
[2022-08-26 11:49:16] INFO  WEBrick::HTTPServer#start: pid=3802 port=38185
Open this page in web browser: https://accounts.google.com/o/oauth2/auth?xxxxxx
[2022-08-26 11:49:31] INFO  going to shutdown ...
[2022-08-26 11:49:32] INFO  WEBrick::HTTPServer#start done.
```